### PR TITLE
docs: add CLAUDE.md for codebase guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 这个仓库是什么
+
+Go 编写的 CLI 工具 `upgrade`，用于按既定路径升级 Alauda 平台上的 Operator，并在每个版本边界执行用户定义的测试命令，以此验证升级后历史数据仍然兼容。它本身不包含被测产品的测试用例 —— 测试用例由 `testCommand`（通常是 `make prepare`/`make upgrade`/`make test`）在外部工作目录中执行。
+
+## 常用命令
+
+```bash
+go build -o upgrade ./main.go            # 构建二进制
+go test ./...                            # 跑单元测试（当前 pkg/ 下无 _test.go，仅作语法检查）
+go test ./pkg/operator/operatorhub/...   # 跑单个包的测试（包含子目录）
+go vet ./...                             # 静态检查
+go mod tidy                              # 同步依赖
+
+# 运行升级（需要 KUBECONFIG）
+export KUBECONFIG=<path>
+./upgrade --config upgrade.yaml --log-level debug
+./upgrade --workspace /app/testing       # 覆盖配置中的 workspace
+```
+
+发版由 `.github/workflows/build.yml` 在打 `v*` tag 时触发，矩阵构建 linux/darwin × amd64/arm64，并自动创建 GitHub Release。
+
+## 架构（big picture）
+
+### 数据流
+
+`config.yaml` → `cmd.UpgradeCommand.Execute` → 对每条 `UpgradePath`，按序遍历 `Versions`：
+
+1. `operator.UpgradeOperator(ctx, version)` —— 把集群升级到该版本
+2. `bash -c <testCommand>` 在 `OperatorConfig.Workspace`（可被 `version.TestSubPath` 进一步嵌套）下执行，stdout/stderr 通过 `io.MultiWriter` 同时打印和捕获（见 `pkg/exec/exec.go`）
+
+第一个版本的默认 `testCommand` 是 `REPO=allure make prepare`（准备测试数据），后续版本默认是 `REPO=allure make upgrade`（验证数据 + 升级断言）。`config.Immediate=true` 时遇到错误立即停止；否则继续下一条 path。
+
+### Operator 抽象
+
+`pkg/operator/interface.go` 定义了仅一个方法的接口 `OperatorInterface.UpgradeOperator`。Factory（`factory.go`）根据 `operatorConfig.type` 选择实现：
+
+- **`operatorhub`（默认）** —— `pkg/operator/operatorhub/`。生产路径。通过 dynamic client + `unstructured` 操作三类资源：
+  - Alauda 自定义资源 `app.alauda.io/v1alpha1` 下的 `Artifact` / `ArtifactVersion`（系统命名空间硬编码为 `cpaas-system`，OLM 源名硬编码为 `platform`）
+  - OLM 标准资源 `Subscription` / `InstallPlan` / `ClusterServiceVersion` / `PackageManifest`
+  - 升级流程：`InstallArtifactVersion`（创建 ArtifactVersion → 等 phase=Present → 等 PackageManifest 出现对应 CSV）→ `InstallSubscription`（先删旧 Sub + 旧 CSV → 创建 Subscription `installPlanApproval: Manual` → 等 InstallPlan → 把 `spec.approved=true` → 等 CSV phase=Succeeded）
+- **`local`** —— `pkg/operator/local/operator.go`。本地开发用，直接在 workspace 里跑 `make deploy`（可被 `operatorConfig.command` 覆盖），不接 OLM。
+
+新增 Operator 类型时：在 `pkg/operator/` 下加子包实现 `OperatorInterface`，并在 `factory.go` 的 `CreateOperator` switch 中注册。
+
+### 配置
+
+`pkg/config/config.go` 是单一事实源。注意 `defaultConfig()` 会填充默认值（workspace=`./`、type=`operatorhub`、artifactPrefix=`operatorhub`、interval=5s、timeout=10m）；新增字段时务必在这里加默认值，避免空值穿透到 client 调用。
+
+Artifact 名称约定：未显式给 `artifact` 字段时，自动拼成 `<artifactPrefix>-<name>`（例如 `operatorhub-gitlab-ce-operator`）。ArtifactVersion 名约定为 `<artifact>.<bundleVersion>`。
+
+## 写代码时要注意的硬约束
+
+- **不要把命名空间或 OLM source 写成参数** —— 当前实现里 `cpaas-system` 和 `source: platform` 是硬编码常量，跨 Operator 共用。如果业务上需要支持其他来源，先和用户确认。
+- **InstallPlan 一定是手动审批模式** —— `installPlanApproval: "Manual"`，由 `InstallSubscription` 自己 patch `spec.approved=true`。不要改成 Automatic，否则升级时序会乱。
+- **新加 GVR 时统一在 `operator.go` 顶部声明** —— 见 `artifactGVR` / `subscriptionGVR` 等，不要在调用点 inline。
+- **轮询用 `wait.PollUntilContextTimeout`** —— 间隔/超时都从 `OperatorConfig.Interval` / `Timeout` 拿，不要写常量。
+- **日志走 knative `logging.FromContext(ctx)`** —— `cmd/upgrade_command.go` 在 ctx 上注入了 zap sugar logger，子包不要再自己起 logger。
+- **YAML 字段大小写**：`config.go` 用的是 `yaml:"xxx,omitempty"` 小写驼峰（`operatorConfig`、`upgradePaths`、`bundleVersion`），demo 配置与 README 也是这套；改字段时同步改三处。
+
+## PR / 协作流程
+
+PR 评论触发的命令（`/lgtm`、`/merge`、`/cherry-pick`、`/retest` 等）由 `.tekton/pr-manage.yaml` 接管，引用外部 pipeline `AlaudaDevops/toolbox/pr-cli`。本地无需关心这些。


### PR DESCRIPTION
## 目的

为 Claude Code 及未来贡献者新增项目级 `CLAUDE.md`，记录从多文件阅读才能拼出来的 "big picture"，让新人 / agent 快速上手。

## 内容范围

- **项目本质**：CLI `upgrade` 按既定路径升级 Alauda Operator，并在每个版本边界跑用户定义的 `testCommand`；本身不含被测产品测试用例
- **常用命令**：`go build` / `go test` / `go vet` / `./upgrade --config`
- **数据流**：`config.yaml` → `cmd.UpgradeCommand.Execute` → `operator.UpgradeOperator` → `bash -c testCommand`
- **Operator 抽象**：`OperatorInterface` 单方法接口；factory 根据 `operatorConfig.type` 分发到 `operatorhub`（默认，OLM + Alauda Artifact/ArtifactVersion）或 `local`（`make deploy`）
- **硬约束**：
  - `cpaas-system` 和 OLM source `platform` 是硬编码常量，跨 Operator 共用
  - InstallPlan 必须 Manual 模式，由代码 patch `approved=true`
  - 新增 GVR 在 `operator.go` 顶部声明
  - 轮询用 `wait.PollUntilContextTimeout` 复用 `OperatorConfig.Interval/Timeout`
  - 日志走 knative `logging.FromContext(ctx)`
- **YAML 字段约定**：小写驼峰（`operatorConfig` / `upgradePaths` / `bundleVersion`），改字段时同步改 `config.go` + `demo.yaml` + `README.md`
- **PR 协作流程**：`.tekton/pr-manage.yaml` 接管 `/lgtm` `/merge` 等命令

## 由来

由 Claude Code 的 `/init` 命令初始扫描仓库生成，对照 `README.md` / `Dockerfile` / `pkg/` 各包 / `cmd/` / `go.mod` 提炼。**只记录从代码本身不容易直接看出来的架构事实和硬约束**，避免重复 `README.md` 已覆盖的使用说明。

## 与 #11 的关系

[#11](https://github.com/AlaudaDevops/upgrade-test/pull/11) 是 violet 上架 + OLM rolling 升级的计划文档 PR。两者独立：
- 本 PR：项目元文档，独立于具体特性
- #11：单一特性的设计 plan

CLAUDE.md 越早合并越能帮到 #11 后续实施 PR 的 reviewer（不必每次重读全仓推断架构）。

## Test Plan

仅含一个 markdown 文件，无代码改动：
- ✅ 不需要 `go build` / `go vet`
- ✅ 在 GitHub 预览渲染、章节层级、代码块格式
- ✅ 内容准确性：每条 "硬约束" 都可在源码中找到对应行（评审者抽检 2-3 条即可）